### PR TITLE
MOD-03: golden fixture corpus

### DIFF
--- a/tests/golden/README.md
+++ b/tests/golden/README.md
@@ -1,0 +1,11 @@
+# Golden Fixtures
+
+These fixtures are used to lock HTML→LaTeX output behavior during modernization.
+
+- Source of truth: `cases.json`
+- Each case contains `name`, `html`, and `expected`.
+- Expected outputs are based on current template semantics and may be adjusted after Python 3 + justhtml migration.
+
+Notes:
+- Whitespace and line endings may be normalized in future tests.
+- The goal is to detect unintended output drift once the new parser is wired in.

--- a/tests/golden/cases.json
+++ b/tests/golden/cases.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "p_simple",
+    "html": "<p>Hello World</p>",
+    "expected": "\\noindent Hello World\\par"
+  },
+  {
+    "name": "h1_simple",
+    "html": "<h1>Title</h1>",
+    "expected": "\\section{Title}"
+  },
+  {
+    "name": "br_in_p",
+    "html": "<p>Hello<br/>World</p>",
+    "expected": "\\noindent Hello\\newlineWorld\\par"
+  },
+  {
+    "name": "ul_li",
+    "html": "<ul><li>One</li><li>Two</li></ul>",
+    "expected": "\\begin{itemize}[noitemsep,nosep]\\begin{item}One\\end{item}\\begin{item}Two\\end{item}\\end{itemize}"
+  },
+  {
+    "name": "a_link",
+    "html": "<a href=\"https://example.com\">Example</a>",
+    "expected": "\\href{https://example.com}{Example}"
+  }
+]


### PR DESCRIPTION
## Summary
- add golden fixture corpus (HTML inputs + expected LaTeX outputs)
- document fixture usage for future tests

## Testing
- not run (fixtures only)

Closes #22
