### PR TITLE
MOD-08: upgrade dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ At [ClassKlap](https://www.classklap.com/), we develop personalized learning sol
 
 - **Python 3.10+** (primary target: latest stable 3.14.x)
 - Dependencies managed via `uv` and `pyproject.toml`
-- Some system packages may still be required for optional features:
-  - `enchant` (for spellcheck via `pyenchant`)
+- Spellcheck is optional: install the `spellcheck` extra and ensure the system `enchant` library is available.
 
 ---
 
@@ -71,6 +70,12 @@ At [ClassKlap](https://www.classklap.com/), we develop personalized learning sol
 
    ```bash
    uv sync
+   ```
+
+   Optional (spellcheck support):
+
+   ```bash
+   uv sync --extra spellcheck
    ```
 
 3. **Install** HTML2LaTeX (in “editable” mode):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,14 @@ classifiers = [
 ]
 
 dependencies = [
-  "Jinja2>=3.1",
-  "html2text",
-  "justhtml",
-  "pyenchant",
+  "Jinja2>=3.1.6",
+  "html2text>=2025.4.15",
+  "justhtml>=0.20.0",
+]
+
+[project.optional-dependencies]
+spellcheck = [
+  "pyenchant>=3.3.0",
 ]
 
 [project.urls]
@@ -43,21 +47,21 @@ Issues = "https://github.com/pankaj28843/html2latex/issues"
 # NOTE: demo app deps are in demo group
 
 dev = [
-  "ipdb",
-  "ipython",
+  "ipdb>=0.13.13",
+  "ipython>=8.0",
 ]
 
 test = [
-  "pytest",
+  "pytest>=9.0.2",
 ]
 
 lint = [
-  "ruff",
+  "ruff>=0.14.11",
 ]
 
 demo = [
-  "Flask",
-  "redis",
+  "Flask>=3.1.2",
+  "redis>=7.1.0",
 ]
 
 [tool.setuptools]

--- a/src/html2latex/utils/spellchecker.py
+++ b/src/html2latex/utils/spellchecker.py
@@ -3,11 +3,23 @@
 import re
 
 # Third Party Stuff
-import enchant
+try:
+    import enchant
+except ImportError:  # pragma: no cover - handled at runtime when spellcheck is enabled
+    enchant = None
 import html2text
 
 DEFAULT_LANGUAGE = "en_UK"
 REGEX_FIND_ENGLISH_WORDS = re.compile(r"[a-zA-Z]+")
+
+
+def _require_enchant():
+    if enchant is None:
+        raise RuntimeError(
+            "Spellcheck requires pyenchant and the system enchant library. "
+            "Install html2latex with the 'spellcheck' extra and ensure "
+            "the enchant system package is available."
+        )
 
 
 def get_word_checker(language=DEFAULT_LANGUAGE):
@@ -15,6 +27,7 @@ def get_word_checker(language=DEFAULT_LANGUAGE):
     Returns a functions which will return True if word is not
     present in dictionary.
     """
+    _require_enchant()
     enchant_dictionary = enchant.Dict(language)
     spell_checker = lambda w: not enchant_dictionary.check(w)
     return spell_checker

--- a/uv.lock
+++ b/uv.lock
@@ -109,6 +109,10 @@ dependencies = [
     { name = "html2text" },
     { name = "jinja2" },
     { name = "justhtml" },
+]
+
+[package.optional-dependencies]
+spellcheck = [
     { name = "pyenchant" },
 ]
 
@@ -131,23 +135,24 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "html2text" },
-    { name = "jinja2", specifier = ">=3.1" },
-    { name = "justhtml" },
-    { name = "pyenchant" },
+    { name = "html2text", specifier = ">=2025.4.15" },
+    { name = "jinja2", specifier = ">=3.1.6" },
+    { name = "justhtml", specifier = ">=0.20.0" },
+    { name = "pyenchant", marker = "extra == 'spellcheck'", specifier = ">=3.3.0" },
 ]
+provides-extras = ["spellcheck"]
 
 [package.metadata.requires-dev]
 demo = [
-    { name = "flask" },
-    { name = "redis" },
+    { name = "flask", specifier = ">=3.1.2" },
+    { name = "redis", specifier = ">=7.1.0" },
 ]
 dev = [
-    { name = "ipdb" },
-    { name = "ipython" },
+    { name = "ipdb", specifier = ">=0.13.13" },
+    { name = "ipython", specifier = ">=8.0" },
 ]
-lint = [{ name = "ruff" }]
-test = [{ name = "pytest" }]
+lint = [{ name = "ruff", specifier = ">=0.14.11" }]
+test = [{ name = "pytest", specifier = ">=9.0.2" }]
 
 [[package]]
 name = "html2text"


### PR DESCRIPTION
## Summary
- raise minimum versions for runtime + dev/test/lint/demo deps; move pyenchant to optional spellcheck extra
- add a guarded spellcheck import with a clear runtime error when the extra is missing
- document spellcheck extra usage in README
- refresh uv.lock (ipython resolves to 8.x for Python < 3.11)

## Testing
- uv lock

Closes #27
