### PR TITLE
MOD-09: explicit Jinja environment

### DIFF
--- a/src/html2latex/setup_texenv.py
+++ b/src/html2latex/setup_texenv.py
@@ -5,13 +5,19 @@ from .utils.text import escape_tex
 
 
 def setup_texenv(loader):
-    texenv = jinja2.Environment(loader=loader)
-    texenv.block_start_string = '((*'
-    texenv.block_end_string = '*))'
-    texenv.variable_start_string = '((('
-    texenv.variable_end_string = ')))'
-    texenv.comment_start_string = '((='
-    texenv.comment_end_string = '=))'
+    texenv = jinja2.Environment(
+        loader=loader,
+        autoescape=False,
+        block_start_string='((*',
+        block_end_string='*))',
+        variable_start_string='(((',
+        variable_end_string=')))',
+        comment_start_string='((=',
+        comment_end_string='=))',
+        trim_blocks=False,
+        lstrip_blocks=False,
+        keep_trailing_newline=False,
+    )
     texenv.filters['escape_tex'] = escape_tex
 
     return texenv


### PR DESCRIPTION
## Summary
- make the Jinja Environment configuration explicit (delimiters, autoescape, whitespace settings)
- keep the LaTeX template delimiters unchanged while documenting explicit defaults

## Testing
- not run (config-only change)

Closes #28
