### PR TITLE
MOD-13: add ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,15 @@ html2latex = ["templates/*.tex", "templates/*.html", "templates/Readme"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+extend-exclude = ["demo-app"]
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "I"]
+ignore = ["E501"]
+
+[tool.ruff.format]
+quote-style = "double"


### PR DESCRIPTION
## Summary
- add initial Ruff configuration in `pyproject.toml` (target version, line length)
- enable basic lint rules (E4/E7/E9/F/I) with E501 ignored
- exclude `demo-app` until it’s ported to Python 3

## Testing
- not run (configuration only)

Closes #32
